### PR TITLE
MXF parsing: terminate strings on the first null character

### DIFF
--- a/src/main/java/com/netflix/imflibrary/MXFPropertyPopulator.java
+++ b/src/main/java/com/netflix/imflibrary/MXFPropertyPopulator.java
@@ -240,7 +240,7 @@ public final class MXFPropertyPopulator
     }
 
     /**
-     * Getter for a string representing the byte[]
+     * Getter for a string representing the byte[], terminating on the first null character
      *
      * @param byteArray the byte array
      * @param charset the charset
@@ -248,7 +248,7 @@ public final class MXFPropertyPopulator
      */
     public static String getString(byte[] byteArray, Charset charset)
     {
-        return new String(byteArray, charset);
+        return new String(byteArray, charset).split("\u0000", 2)[0];
     }
 
     /**


### PR DESCRIPTION
Per SMPTE ST 377-1:2019, a "zero value" can be used to terminate a string.

So, discard any data after the first null character found (if any).

This has the same effect as the implementation for strings in regxmllib at: https://github.com/sandflow/regxmllib/blob/b47b0cdbd6dbf51cae4fb14c3a6a827eb3e0e2cc/src/main/java/com/sandflow/smpte/regxml/FragmentBuilder.java#L902

Note that regxmllib also uses the same `readCharacters` method for MXF properties with a Type of Type Kind "Character", and allows values of this Type to contain the null character.
Photon does not support such "Character" Types (and indeed none have ever been used in MXF according to the SMPTE Metadata Registers). So, no consideration is given to these Types in this patch.